### PR TITLE
Skip directive; platform selection

### DIFF
--- a/rambo/__main__.py
+++ b/rambo/__main__.py
@@ -77,9 +77,10 @@ def main(argv=None):
 
     versions['numpy'] = meta.DEFAULT_MINIMUM_NUMPY_VERSION
 
+    meta.Config.platform = args.platform
+
     mset = meta.MetaSet(
             recipes_dir,
-            platform=args.platform,
             versions=versions,
             dirty=args.dirty,
             manfile=args.manifest)

--- a/rambo/meta.py
+++ b/rambo/meta.py
@@ -18,6 +18,7 @@ import json
 from ._version import __version__
 try:
     import conda_build.api
+    from conda_build.config import Config
 except ImportError:
     print('conda-build must be installed order to use this tool. \n'
           'Either conda-build is not installed, or you are working in an \n'
@@ -71,6 +72,9 @@ class Meta(object):
             self.complete = self.is_complete()
             if self.valid:
                 self.name = self.mdata['package']['name']
+            if self.metaobj.skip():
+                print('skipping on selected platform due to directive: {}'.format(
+                    self.name))
         else:
             print('Recipe directory {0} has no meta.yaml file.'.format(
                 self.recipe_dirname))
@@ -128,7 +132,6 @@ class MetaSet(object):
     def __init__(self,
                  directory,
                  versions,
-                 platform,
                  manfile=None,
                  dirty=False):
         '''Parameters:
@@ -137,7 +140,7 @@ class MetaSet(object):
         versions - Dictionary containing python, numpy, etc, version
           information.'''
         self.metas = []
-        self.platform = platform
+        self.platform = Config.platform
         self.versions = versions
         self.manfile = manfile
         self.manifest = None
@@ -165,11 +168,12 @@ class MetaSet(object):
                 continue
             rdir = directory + '/' + rdirname
             m = Meta(rdir, versions=self.versions, dirty=self.dirty)
-            if m.complete:
-                self.metas.append(m)
-                self.names.append(m.name)
-            else:
-                self.incomplete_metas.append(m)
+            if not m.metaobj.skip():
+                if m.complete:
+                    self.metas.append(m)
+                    self.names.append(m.name)
+                else:
+                    self.incomplete_metas.append(m)
 
     def read_recipes(self, directory):
         recipe_dirnames = os.listdir(directory)


### PR DESCRIPTION
* Skip directive in recipe now causes removal of package from build list on specified platforms.
* Platform flag now sets Conda machinery platform specification to affect behavior throughout operation.